### PR TITLE
Add Localizations to Slash Commands

### DIFF
--- a/setupCommands.js
+++ b/setupCommands.js
@@ -33,57 +33,111 @@ client.on("ready", () => {
 	let promises = [];
 	promises.push(client.application?.commands?.create({
 		name: 'getpoll',
-		description: 'Get information about all polls or specific polls for a Twitch channel (available for 90 days).',
+		nameLocalizations: {
+			de: 'umfrageabrufen'
+		},
+		description: 'Get information about the most recent poll in the authorized Twitch channel',
+		descriptionLocalizations: {
+			de: 'Informationen über die letzte Umfrage des authorisierten Twitch-Kanals abrufen'
+		},
 		type: ApplicationCommandType.ChatInput
 	}));
 	promises.push(client.application?.commands?.create({
 		name: 'poll',
-		description: 'Create a poll for a specific Twitch channel.',
+		nameLocalizations: {
+			de: 'umfrage'
+		},
+		description: 'Create a poll in the authorized Twitch channel',
+		descriptionLocalizations: {
+			de: 'Eine Umfrage im authorisierten Twitch-Kanal erstellen'
+		},
 		type: ApplicationCommandType.ChatInput,
 		options: [
 			{
 				name: 'title',
-				description: 'Question displayed for the poll.',
+				nameLocalizations: {
+					de: 'titel'
+				},
+				description: 'Title displayed in the poll',
+				descriptionLocalizations: {
+					de: 'Der Titel, der in der Umfrage angezeigt werden sollte'
+				},
 				type: ApplicationCommandOptionType.String,
 				required: true
 			},
 			{
 				name: 'choices',
-				description: 'List of the poll choices (separated by semicolon).',
+				nameLocalizations: {
+					de: 'antworten'
+				},
+				description: 'List of the poll choices (separated by semicolon)',
+				descriptionLocalizations: {
+					de: 'Eine Liste an Antwortmöglichkeiten (getrennt durch Strichpunkte/Semikolon)'
+				},
 				type: ApplicationCommandOptionType.String,
 				required: true
 			},
 			{
 				name: 'duration',
+				nameLocalizations: {
+					de: 'dauer'
+				},
 				description: 'Total duration for the poll (Default: in seconds).',
+				descriptionLocalizations: {
+					de: 'Gesamtdauer der Umfrage (Standardmäßig in Sekunden)'
+				},
 				type: ApplicationCommandOptionType.Integer,
 				required: true
 			},
 			{
 				name: 'unit',
-				description: 'Which unit to use for duration.',
+				nameLocalizations: {
+					de: 'einheit'
+				},
+				description: 'Which unit to use for the duration',
+				descriptionLocalizations: {
+					de: 'Welche Einheit soll für die Dauer genutzt werden'
+				},
 				type: ApplicationCommandOptionType.String,
 				required: false,
 				choices: [
 					{
 						name: 'Minutes',
+						nameLocalizations: {
+							de: 'Minuten'
+						},
 						value: 'minutes'
 					},
 					{
 						name: 'Seconds',
+						nameLocalizations: {
+							de: 'Sekunden'
+						},
 						value: 'seconds'
 					}
 				]
 			},
 			{
 				name: 'channelpoints',
-				description: 'Indicates if Channel Points can be used for voting.',
+				nameLocalizations: {
+					de: 'kanalpunkte'
+				},
+				description: 'Indicates if Channel Points can be used for voting',
+				descriptionLocalizations: {
+					de: 'Gibt an, ob Kanalpunkte für die Abstimmung verwendet werden können'
+				},
 				type: ApplicationCommandOptionType.Boolean,
 				required: false
 			},
 			{
 				name: 'cpnumber',
+				nameLocalizations: {
+					de: 'kpanzahl'
+				},
 				description: 'Number of Channel Points required to vote once with Channel Points.',
+				descriptionLocalizations: {
+					de: 'Anzahl der Kanalpunkte, die für eine Stimme mit Kanalpunkten benötigt wird'
+				},
 				type: ApplicationCommandOptionType.Integer,
 				required: false
 			}
@@ -91,21 +145,39 @@ client.on("ready", () => {
 	}));
 	promises.push(client.application?.commands?.create({
 		name: 'endpoll',
-		description: 'End a poll that is currently active.',
+		nameLocalizations: {
+			de: 'umfragebeenden'
+		},
+		description: 'End the poll that is currently active',
+		descriptionLocalizations: {
+			de: 'Die Umfrage, die aktuell läuft, beenden'
+		},
 		type: ApplicationCommandType.ChatInput,
 		options: [
 			{
 				name: 'status',
-				description: 'The poll status to be set.',
+				/*nameLocalizations: {
+					de: 'status'
+				},*/
+				description: 'The poll status to be set',
+				descriptionLocalizations: {
+					de: 'Der Status, auf den die Umfrage gesetzt werden soll'
+				},
 				type: ApplicationCommandOptionType.String,
 				required: true,
 				choices: [
 					{
-						name: 'Terminated (End the poll manually, but allow it to be viewed publicly.)',
+						name: 'Terminated (End the poll manually, but allow it to be viewed publicly)',
+						nameLocalizations: {
+							de: 'Beendet (Umfrage manuell beenden, aber öffentlich sichtbar lassen)'
+						},
 						value: 'TERMINATED'
 					},
 					{
-						name: 'Archived (End the poll manually and do not allow it to be viewed publicly.)',
+						name: 'Archived (End the poll manually and do not allow it to be viewed publicly)',
+						nameLocalizations: {
+							de: 'Archiviert (Umfrage manuell beenden, aber nicht öffentlich sichtbar lassen)'
+						},
 						value: 'ARCHIVED'
 					}
 				]
@@ -114,44 +186,86 @@ client.on("ready", () => {
 	}));
 	promises.push(client.application?.commands?.create({
 		name: 'getprediction',
-		description: 'Get information about all Channel Points Predictions or specific Channel Points Predictions.',
+		nameLocalizations: {
+			de: 'vorhersageabrufen'
+		},
+		description: 'Get information about the most recent prediction in the authorized Twitch channel',
+		descriptionLocalizations: {
+			de: 'Informationen über die letzte Vorhersage des authorisierten Twitch-Kanals abrufen'
+		},
 		type: ApplicationCommandType.ChatInput
 	}));
 	promises.push(client.application?.commands?.create({
 		name: 'prediction',
-		description: 'Create a Channel Points Prediction for a specific Twitch channel.',
+		nameLocalizations: {
+			de: 'vorhersage'
+		},
+		description: 'Create a prediction in the authorized Twitch channel',
+		descriptionLocalizations: {
+			de: 'Eine Vorhersage im authorisierten Twitch-Kanal erstellen'
+		},
 		type: ApplicationCommandType.ChatInput,
 		options: [
 			{
 				name: 'title',
-				description: 'Title for the Prediction.',
+				nameLocalizations: {
+					de: 'titel'
+				},
+				description: 'Title for the prediction',
+				descriptionLocalizations: {
+					de: 'Titel für die Vorhersage'
+				},
 				type: ApplicationCommandOptionType.String,
 				required: true
 			},
 			{
 				name: 'outcomes',
-				description: 'List of the outcomes (separated by semicolon, first is blue, second is pink).',
+				nameLocalizations: {
+					'ergebnisse'
+				},
+				description: 'List of the outcomes (separated by semicolon, first is blue, second is pink)',
+				descriptionLocalizations: {
+					'Liste der möglichen Ergebnisse (getrennt durch Strichpunkte/Semikolon, erste ist blau, zweite ist rosa)'
+				},
 				type: ApplicationCommandOptionType.String,
 				required: true
 			},
 			{
-				name: 'duration',
-				description: 'Total duration for the Prediction (Default: in seconds).',
+				name: 'duration', // prediction window
+				nameLocalizations: {
+					de: 'dauer'
+				},
+				description: 'Total duration for the prediction (Default: in seconds)',
+				descriptionLocalizations: {
+					de: 'Gesamtdauer der Vorhersage (Standardmäßig in Sekunden)'
+				},
 				type: ApplicationCommandOptionType.Integer,
 				required: true
 			},
 			{
 				name: 'unit',
+				nameLocalizations: {
+					de: 'einheit'
+				},
 				description: 'Which unit to use for duration.',
+				descriptionLocalizations: {
+					de: 'Welche Einheit soll für die Dauer genutzt werden'
+				},
 				type: ApplicationCommandOptionType.String,
 				required: false,
 				choices: [
 					{
 						name: 'Minutes',
+						nameLocalizations: {
+							de: 'Minuten'
+						},
 						value: 'minutes'
 					},
 					{
 						name: 'Seconds',
+						nameLocalizations: {
+							de: 'Sekunden'
+						},
 						value: 'seconds'
 					}
 				]
@@ -160,32 +274,59 @@ client.on("ready", () => {
 	}));
 	promises.push(client.application?.commands?.create({
 		name: 'endprediction',
-		description: 'Lock, resolve, or cancel a Channel Points Prediction.',
+		nameLocalizations: {
+			de: 'vorhersagebeeenden'
+		},
+		description: 'Lock, resolve, or cancel a prediction.',
+		descriptionLocalizations: {
+			de: 'Eine Vorhersage sperren, auflösen oder abbrechen'
+		},
 		type: ApplicationCommandType.ChatInput,
 		options: [
 			{
 				name: 'status',
-				description: 'The Prediction status to be set.',
+				/*nameLocalizations: {
+					de: 'status'
+				},*/
+				description: 'The prediction status to be set',
+				descriptionLocalizations: {
+					de: 'Der Status, auf den die Vorhersage gesetzt werden soll'
+				},
 				type: ApplicationCommandOptionType.String,
 				required: true,
 				choices: [
 					{
-						name: 'Resolved (A winning outcome has been chosen and the Channel Points have been distributed.)',
+						name: 'Resolved (A winning outcome has been chosen and the Channel Points have been distributed)',
+						nameLocalizations: {
+							de: 'Aufgelöst (Ein Gewinner wurde ausgewählt und die Kanalpunkte wurden verteilt)'
+						},
 						value: 'RESOLVED'
 					},
 					{
-						name: 'Canceled (The Prediction has been canceled and the Channel Points have been refunded.)',
+						name: 'Canceled (The prediction has been canceled and the Channel Points have been refunded)',
+						nameLocalizations: {
+							de: 'Abgebrochen (Die Vorhersage wurde abgebrochen und die Kanalpunkte wurden zurückerstattet)'
+						},
 						value: 'CANCELED'
 					},
 					{
-						name: 'Locked (The Prediction has been locked and viewers can no longer make predictions.)',
+						name: 'Locked (The prediction has been locked and viewers can no longer make predictions)',
+						nameLocalizations: {
+							de: 'Gesperrt (Die Vorhersage wurde gesperrt und die Zuschauer können nicht mehr länger vorhersagen)'
+						},
 						value: 'LOCKED'
 					}
 				]
 			},
 			{
 				name: 'winning_outcome_id',
-				description: 'ID of the winning outcome for the Prediction (Required if status is Resolved).',
+				nameLocalizations: {
+					de: 'gewinnendes_ergebnis_id'
+				},
+				description: 'ID of the winning outcome for the Prediction (Required if status is "Resolved")',
+				descriptionLocalizations: {
+					de: 'Id des Ergebnisses, welches die Vorhersage gewinnen soll (Erforderlich, wenn status "Aufgelöst" ist)'
+				},
 				type: ApplicationCommandOptionType.String,
 				required: false
 			}

--- a/setupCommands.js
+++ b/setupCommands.js
@@ -56,7 +56,7 @@ client.on("ready", () => {
 			{
 				name: 'title',
 				nameLocalizations: {
-					de: 'Frage'
+					de: 'frage'
 				},
 				description: 'Title displayed in the poll',
 				descriptionLocalizations: {

--- a/setupCommands.js
+++ b/setupCommands.js
@@ -221,11 +221,11 @@ client.on("ready", () => {
 			{
 				name: 'outcomes',
 				nameLocalizations: {
-					'ergebnisse'
+					de: 'ergebnisse'
 				},
 				description: 'List of the outcomes (separated by semicolon, first is blue, second is pink)',
 				descriptionLocalizations: {
-					'Liste der möglichen Ergebnisse (getrennt durch Strichpunkte/Semikolon, erste ist blau, zweite ist rosa)'
+					de: 'Liste der möglichen Ergebnisse (getrennt durch Strichpunkte/Semikolon, erste ist blau, zweite ist rosa)'
 				},
 				type: ApplicationCommandOptionType.String,
 				required: true

--- a/setupCommands.js
+++ b/setupCommands.js
@@ -223,9 +223,9 @@ client.on("ready", () => {
 				nameLocalizations: {
 					de: 'ergebnisse'
 				},
-				description: 'List of the outcomes (separated by semicolon, first is blue, second is pink)',
+				description: 'List of the outcomes (separated by semicolon)',
 				descriptionLocalizations: {
-					de: 'Liste der möglichen Ergebnisse (getrennt durch Strichpunkte/Semikolon, erste ist blau, zweite ist rosa)'
+					de: 'Liste der möglichen Ergebnisse (getrennt durch Strichpunkte/Semikolon)'
 				},
 				type: ApplicationCommandOptionType.String,
 				required: true

--- a/setupCommands.js
+++ b/setupCommands.js
@@ -56,11 +56,11 @@ client.on("ready", () => {
 			{
 				name: 'title',
 				nameLocalizations: {
-					de: 'titel'
+					de: 'Frage'
 				},
 				description: 'Title displayed in the poll',
 				descriptionLocalizations: {
-					de: 'Der Titel, der in der Umfrage angezeigt werden sollte'
+					de: 'Der Titel, der in der Umfrage angezeigt werden soll'
 				},
 				type: ApplicationCommandOptionType.String,
 				required: true
@@ -156,9 +156,9 @@ client.on("ready", () => {
 		options: [
 			{
 				name: 'status',
-				/*nameLocalizations: {
+				nameLocalizations: {
 					de: 'status'
-				},*/
+				},
 				description: 'The poll status to be set',
 				descriptionLocalizations: {
 					de: 'Der Status, auf den die Umfrage gesetzt werden soll'
@@ -176,7 +176,7 @@ client.on("ready", () => {
 					{
 						name: 'Archived (End the poll manually and do not allow it to be viewed publicly)',
 						nameLocalizations: {
-							de: 'Archiviert (Umfrage manuell beenden, aber nicht öffentlich sichtbar lassen)'
+							de: 'Archiviert (Umfrage manuell beenden und auf privat stellen)'
 						},
 						value: 'ARCHIVED'
 					}
@@ -247,7 +247,7 @@ client.on("ready", () => {
 				nameLocalizations: {
 					de: 'einheit'
 				},
-				description: 'Which unit to use for duration.',
+				description: 'Which unit to use for duration',
 				descriptionLocalizations: {
 					de: 'Welche Einheit soll für die Dauer genutzt werden'
 				},
@@ -277,7 +277,7 @@ client.on("ready", () => {
 		nameLocalizations: {
 			de: 'vorhersagebeeenden'
 		},
-		description: 'Lock, resolve, or cancel a prediction.',
+		description: 'Lock, resolve, or cancel a prediction',
 		descriptionLocalizations: {
 			de: 'Eine Vorhersage sperren, auflösen oder abbrechen'
 		},
@@ -312,7 +312,7 @@ client.on("ready", () => {
 					{
 						name: 'Locked (The prediction has been locked and viewers can no longer make predictions)',
 						nameLocalizations: {
-							de: 'Gesperrt (Die Vorhersage wurde gesperrt und die Zuschauer können nicht mehr länger vorhersagen)'
+							de: 'Gesperrt (Die Vorhersage wurde gesperrt und Zuschauer können nicht länger vorhersagen)'
 						},
 						value: 'LOCKED'
 					}
@@ -323,9 +323,9 @@ client.on("ready", () => {
 				nameLocalizations: {
 					de: 'gewinnendes_ergebnis_id'
 				},
-				description: 'ID of the winning outcome for the Prediction (Required if status is "Resolved")',
+				description: 'ID of the winning outcome for the prediction (Required if status is "Resolved")',
 				descriptionLocalizations: {
-					de: 'Id des Ergebnisses, welches die Vorhersage gewinnen soll (Erforderlich, wenn status "Aufgelöst" ist)'
+					de: 'ID des Ergebnisses, welches die Vorhersage gewinnen soll (Erforderlich, wenn status "Aufgelöst" ist)'
 				},
 				type: ApplicationCommandOptionType.String,
 				required: false


### PR DESCRIPTION
This is just changing the slash commands to also include a german translation where possible (if the language of the discord client is set to German).
This should be like a first step to allow additional languages in the bot.

Closes #14 