### PR TITLE
Fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,4 +1,5 @@
 name: CI
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Potential fix for [https://github.com/Wissididom/Twitch-Discord-Mod-Bot/security/code-scanning/6](https://github.com/Wissididom/Twitch-Discord-Mod-Bot/security/code-scanning/6)

In general, the fix is to declare an explicit `permissions` block in the workflow (either at the root level or per job) that grants only the minimal scopes required. For this CI formatting job, read-only access to repository contents is sufficient, since it just checks out the code, installs dependencies, and runs `prettier` plus a local `git diff` without pushing changes.

The best way to fix this without changing existing functionality is to add a `permissions` block at the workflow root (top level, alongside `name` and `on`) specifying `contents: read`. This will apply to all jobs in the workflow, including `check-format`, and it matches CodeQL’s suggested minimal starting point. No other scopes (like `pull-requests` write) are needed, because the workflow does not modify PRs or post comments.

Concretely, in `.github/workflows/prettier.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: CI` and the `on:` block (around line 2–3). No imports, methods, or other definitions are needed, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
